### PR TITLE
wrong log level configuration and usage of variable

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -3,5 +3,5 @@
     "password"           : "bot user password",
     "domain"             : "circuitsandbox.net",
     "apiKey"             : "google translation API key",
-    "apiLogLevel"        : "error"
+    "sdkLogLevel"        : "error"
 }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var bunyan = require('bunyan');
 var sdkLogger = bunyan.createLogger({
     name: 'sdk',
     stream: process.stdout,
-    level: 'config.sdkLogLevel'
+    level: config.sdkLogLevel
 });
 
 // Application logger


### PR DESCRIPTION
Changed "apiLogLevel" to "sdkLogLevel" in config.json.template and removed ' ' around config.sdkLogLevel so it is not treated as a string.
